### PR TITLE
Renomeia o atributo `Terrain` '`background`' da classe `Game` para '`arena`'

### DIFF
--- a/include/game.hpp
+++ b/include/game.hpp
@@ -29,7 +29,7 @@ private:
     vector<Enemy *> enemies;
     vector<Gunshot *> charactersGunshots;
     vector<Terrain *> terrains;
-    Terrain *background;
+    Terrain *arena;
     GLint nCharacters;
     string arenaSVGFilename;
     Dimensions arenaDimensions;
@@ -42,7 +42,7 @@ public:
         this->player = NULL;
         this->enemies = vector<Enemy *>();
         this->terrains = vector<Terrain *>();
-        this->background = NULL;
+        this->arena = NULL;
         this->nCharacters = 0;
         this->arenaSVGFilename = "";
         this->arenaDimensions = {0, 0};
@@ -109,8 +109,8 @@ public:
     void draw_terrains();
 
     /* Arena interface */
-    void set_arena_background(Terrain *background);
-    Terrain *get_arena_background();
+    void set_arena(Terrain *arena);
+    Terrain *get_arena();
     void set_arena_svg_filename(string arenaSVGFilename);
     string get_arena_svg_filename();
     void set_arena_dimensions(Dimensions arenaDimensions);

--- a/main.cpp
+++ b/main.cpp
@@ -54,7 +54,7 @@ void RenderString(float x, float y)
     }
 
     // Raster position for the text, determined by the player's position
-    glRasterPos2f(game->get_player()->get_center().x - stringMargin, -game->get_arena_background()->get_center().y - game->get_arena_background()->get_height() / 2);
+    glRasterPos2f(game->get_player()->get_center().x - stringMargin, -game->get_arena()->get_center().y - game->get_arena()->get_height() / 2);
 
     // Navigate through the string and display each character
     char *text;
@@ -87,8 +87,8 @@ void render_scene()
     else
     {
         // cout << "\nDrawing game elements:" << endl;
-        // cout << "Drawing background... ";
-        game->get_arena_background()->draw_terrain();
+        // cout << "Drawing arena... ";
+        game->get_arena()->draw_terrain();
         // cout << "Drawing terrains... ";
         game->draw_terrains();
         // cout << "Drawing player... ";
@@ -243,13 +243,13 @@ void idle(void)
     {
         glMatrixMode(GL_PROJECTION); // Select the projection matrix
         glLoadIdentity();
-        glOrtho(-game->get_arena_background()->get_height() / 2 + player->get_center().x,                     // X coordinate of left edge
-                game->get_arena_background()->get_height() / 2 + player->get_center().x,                      // X coordinate of right edge
-                (-game->get_arena_background()->get_center().y - game->get_arena_background()->get_height()), // Y coordinate of bottom edge
-                -game->get_arena_background()->get_center().y,                                                // Y coordinate of top edge
-                -1,                                                                                           // Z coordinate of the “near” plane
-                1);                                                                                           // Z coordinate of the “far” plane
-        glMatrixMode(GL_MODELVIEW);                                                                           // Select the projection matrix
+        glOrtho(-game->get_arena()->get_height() / 2 + player->get_center().x,          // X coordinate of left edge
+                game->get_arena()->get_height() / 2 + player->get_center().x,           // X coordinate of right edge
+                (-game->get_arena()->get_center().y - game->get_arena()->get_height()), // Y coordinate of bottom edge
+                -game->get_arena()->get_center().y,                                     // Y coordinate of top edge
+                -1,                                                                     // Z coordinate of the “near” plane
+                1);                                                                     // Z coordinate of the “far” plane
+        glMatrixMode(GL_MODELVIEW);                                                     // Select the projection matrix
     }
     else // if global camera is enabled
     {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -366,7 +366,7 @@ bool Character::is_inside_terrain(Terrain *terrain)
     {
         if (this->center.x + this->trunkWidth / 2 >= terrainPos.x && this->center.x - this->trunkWidth / 2 <= terrainPos.x + terrain->get_width())
         {
-            // Collided with black Terrain (not arena background) from above (make Character able to jump)
+            // Collided with black Terrain (not arena Terrain) from above (make Character able to jump)
             if (terrain->get_color().b != 1.0 && this->center.y <= terrainPos.y)
             {
                 this->isFalling = false;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5,8 +5,8 @@ using namespace std;
 
 GLdouble Game::get_random_z_inside_arena_given_radius(GLfloat radius)
 {
-    GLfloat arenaLength = this->background->get_length();
-    Point arenaPos = this->background->get_center();
+    GLfloat arenaLength = this->arena->get_length();
+    Point arenaPos = this->arena->get_center();
 
     GLdouble initialZ = arenaPos.z + radius;
     GLdouble finalZ = arenaPos.z + arenaLength - radius;
@@ -61,7 +61,7 @@ void Game::make_a_character_jump(Character *character, GLfloat frameTime)
 
 bool Game::has_player_reached_arena_end()
 {
-    return this->player->get_center().x + (this->player->get_trunk_width() * 1.2) / 2 >= this->background->get_center().x + this->background->get_width();
+    return this->player->get_center().x + (this->player->get_trunk_width() * 1.2) / 2 >= this->arena->get_center().x + this->arena->get_width();
 }
 
 bool Game::has_player_won()
@@ -206,8 +206,8 @@ bool Game::check_collision_gunshot_non_character(Gunshot *gunshot)
 
 bool Game::is_gunshot_outside_arena(Gunshot *gunshot)
 {
-    Terrain *arenaTerrain = this->background;
-    Point arenaPos = this->background->get_center();
+    Terrain *arenaTerrain = this->arena;
+    Point arenaPos = this->arena->get_center();
 
     if (gunshot->get_center().y - gunshot->get_radius() < arenaPos.y ||
         gunshot->get_center().y + gunshot->get_radius() > arenaPos.y + arenaTerrain->get_height())
@@ -350,7 +350,7 @@ void Game::move_enemy_randomly(Enemy *enemy, GLfloat frameTime)
 
 void Game::enemy_shoot_at_player(Enemy *enemy, GLfloat frameTime)
 {
-    GLdouble enemyXViewDistance = this->get_arena_background()->get_height() * 0.4;
+    GLdouble enemyXViewDistance = this->get_arena()->get_height() * 0.4;
     GLdouble enemyYViewDistance = enemy->get_height() * 3;
 
     if (enemy->get_center().x - enemyXViewDistance < this->player->get_center().x &&
@@ -442,7 +442,7 @@ void Game::free()
     this->enemies.clear();
     this->terrains.clear();
 
-    delete this->background;
+    delete this->arena;
 }
 
 void Game::reset_game()
@@ -454,8 +454,8 @@ void Game::reset_game()
 
 bool Game::is_character_outside_arena(Character *character)
 {
-    Terrain *arenaTerrain = this->background;
-    Point arenaPos = this->background->get_center();
+    Terrain *arenaTerrain = this->arena;
+    Point arenaPos = this->arena->get_center();
 
     // Check if player is outside the arena vertically
     if (character->get_center().y - character->get_radius() < arenaPos.y ||
@@ -482,7 +482,7 @@ bool Game::is_character_outside_arena(Character *character)
     // Player collided with bottom of the arena and should mark it as the terrain 'below'
     if (character->get_center().y + character->get_radius() > arenaPos.y + arenaTerrain->get_height())
     {
-        character->set_terrain_below(this->get_arena_background());
+        character->set_terrain_below(this->get_arena());
     }
 
     // Check if player is outside the arena horizontally
@@ -591,14 +591,14 @@ void Game::draw_player()
     this->player->draw_character();
 }
 
-void Game::set_arena_background(Terrain *background)
+void Game::set_arena(Terrain *arena)
 {
-    this->background = background;
+    this->arena = arena;
 }
 
-Terrain *Game::get_arena_background()
+Terrain *Game::get_arena()
 {
-    return this->background;
+    return this->arena;
 }
 
 GLint Game::get_n_characters()

--- a/src/svg_reader.cpp
+++ b/src/svg_reader.cpp
@@ -76,16 +76,16 @@ void parseRect(XMLElement *rect, Game *game)
         terrain->draw_terrain();
         game->add_terrain(terrain);
     }
-    // Background rectangle
+    // Arena rectangle
     else if (rectFill == "blue")
     {
-        cout << "-- BACKGROUND --" << endl;
+        cout << "-- ARENA --" << endl;
         color = {0.0, 0.0, 0.75};
 
-        Terrain *background = new Terrain(center, width, height, length, color);
+        Terrain *arena = new Terrain(center, width, height, length, color);
         Dimensions dimensions = {width, height};
-        // Disclaimer: arena_background and arena_dimensions are a bit redundant
-        game->set_arena_background(background);
+        // Disclaimer: arena and arena_dimensions are a bit redundant
+        game->set_arena(arena);
         game->set_arena_dimensions(dimensions);
     }
 


### PR DESCRIPTION
Este PR torna o nome do atributo mais acurado, principalmente considerando o espaço 3D que criaremos. No entanto, a arena ainda não é realmente um `Terrain`, estando mais para algo como '`Rect`' (se existisse).

Resolves #11.