### PR TITLE
Atualiza `Gunshot` para considerar espaço 3D

### DIFF
--- a/include/gunshot.hpp
+++ b/include/gunshot.hpp
@@ -26,7 +26,7 @@ class Gunshot
     Color color;
 
 private:
-    void draw_circ(GLint radius, GLfloat R, GLfloat G, GLfloat B);
+    void draw_sphere(GLint radius, GLfloat R, GLfloat G, GLfloat B);
     void draw_bullet(GLdouble x, GLdouble y, GLdouble z);
 
 public:

--- a/src/gunshot.cpp
+++ b/src/gunshot.cpp
@@ -36,19 +36,12 @@ void Gunshot::move_gunshot(GLdouble frameTime)
 
 bool Gunshot::is_inside_character(Character *character)
 {
-    // TODO: Also use Z to check if the Gunshot is inside the Character
+    // Check if the Gunshot is inside the Character in a 3D space considering that the character is drawn from the center to the edges.
+    GLdouble xDistGunshot = abs(this->gX - character->get_center().x);
+    GLdouble yDistGunshot = abs(this->gY - character->get_center().y);
+    GLdouble zDistGunshot = abs(this->gZ - character->get_center().z);
 
-    // Check if the Gunshot is inside the Character considering that the character is drawn from the center to the edges (hence the divisions by 2)
-    if (this->gX + this->gRadiusGunshot > character->get_center().x - character->get_trunk_width() / 2 &&
-        this->gX - this->gRadiusGunshot < character->get_center().x + character->get_trunk_width() / 2 && this->gY + this->gRadiusGunshot > character->get_center().y - character->get_radius() &&
-        this->gY - this->gRadiusGunshot < character->get_center().y + character->get_radius())
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    return ((xDistGunshot <= character->get_radius()) && (yDistGunshot <= character->get_radius()) && (zDistGunshot <= character->get_radius()));
 }
 
 bool Gunshot::is_inside_terrain(Terrain *terrain)

--- a/src/gunshot.cpp
+++ b/src/gunshot.cpp
@@ -1,14 +1,11 @@
 #include "../include/gunshot.hpp"
 
-// TODO: change to sphere
-void Gunshot::draw_circ(GLint radius, GLfloat R, GLfloat G, GLfloat B)
+// Draw a sphere with given radius and RGB values
+void Gunshot::draw_sphere(GLint radius, GLfloat R, GLfloat G, GLfloat B)
 {
     glColor3f(R * 1.3, G * 1.3, B * 1.3);
-    glBegin(GL_POLYGON);
-    for (int i = 0; i < 360; i += 10)
-    {
-        glVertex2f(radius * 1 * cos(deg_to_radians(i)), radius * 1 * sin(deg_to_radians(i)));
-    }
+    // TODO: Investigate params GLint slices, GLint stacks for glutSolidSphere
+    glutSolidSphere(radius, 20, 20);
     glEnd();
 }
 
@@ -20,8 +17,10 @@ void Gunshot::draw_gunshot()
 void Gunshot::draw_bullet(GLdouble x, GLdouble y, GLdouble z)
 {
     glPushMatrix();
-    glTranslatef(x, -y, 0);
-    draw_circ(this->gRadiusGunshot, this->color.r, this->color.g, this->color.b);
+
+    glTranslatef(x, -y, -z);
+    draw_sphere(this->gRadiusGunshot, this->color.r, this->color.g, this->color.b);
+
     glPopMatrix();
 }
 


### PR DESCRIPTION
Essas mudanças são necessárias para resolve #18 e também (parcialmente) a #15.

Desenha `Gunshot` como uma esfera em vez de um círculo, utiliza `z` para desenhar a posição atual.